### PR TITLE
Add on_change callback to st_navbar.

### DIFF
--- a/streamlit_navigation_bar/__init__.py
+++ b/streamlit_navigation_bar/__init__.py
@@ -20,7 +20,7 @@ from streamlit_navigation_bar.errors import (
 )
 
 
-_RELEASE = False
+_RELEASE = True
 
 if not _RELEASE:
     _st_navbar = components.declare_component(

--- a/streamlit_navigation_bar/__init__.py
+++ b/streamlit_navigation_bar/__init__.py
@@ -257,6 +257,7 @@ def st_navbar(
     options=True,
     adjust=True,
     key=None,
+    on_change=None,
 ):
     """
     Place a navigation bar in your Streamlit app.
@@ -338,6 +339,8 @@ def st_navbar(
         A string or integer to use as a unique key for the component. If this
         is omitted, a key will be generated for the widget based on its
         content. Multiple navbars of the same type may not share the same key.
+    on_change : callable
+        An optional callback invoked when this date_input's value changes.
 
     Returns
     -------
@@ -397,6 +400,7 @@ def st_navbar(
         urls=urls,
         styles=styles,
         key=key,
+        on_change=on_change,
     )
 
     if adjust:


### PR DESCRIPTION
Using query_params and maybe other advanced functions, you often have to define a callback to update the query_params. If this is not done, you have to execute the function twice to get it update correct and you page to show correctly.