### PR TITLE
Fix for not being able to click the sidebar expander when using streamlit 1.38.0

### DIFF
--- a/streamlit_navigation_bar/templates/base.css
+++ b/streamlit_navigation_bar/templates/base.css
@@ -62,7 +62,7 @@ span[data-testid="stMainMenu"] button[data-testid="baseButton-headerNoPadding"]:
 div[data-testid="stAppViewContainer"] {
     pointer-events: none;
 }
-div[data-testid="collapsedControl"] {
+div[data-testid="collapsedControl"], div[data-testid="stSidebarCollapsedControl"] {
     pointer-events: auto;
 }
 section[data-testid="stSidebar"] {
@@ -78,20 +78,24 @@ section.main {
 {% if not options["show_sidebar"] %}
 {% block hide_sidebar %}{% endblock %}
 {% endif %}
-div[data-testid="collapsedControl"] {
+div[data-testid="collapsedControl"], div[data-testid="stSidebarCollapsedControl"] {
     /* Leave space to the right that is equal to the top and bottom */
     left: 0.3125rem;
     
     /* Align the button vertically to the navbar pages */
     top: calc(({{ ui.height }} - 2rem) / 2);
 }
-div[data-testid="collapsedControl"] path:nth-of-type(2) {
+
+div[data-testid="collapsedControl"] path:nth-of-type(2),
+div[data-testid="stSidebarCollapsedControl"] path:nth-of-type(2) {
     fill: {{ ui.color }};
 }
-div[data-testid="collapsedControl"]:hover path:nth-of-type(2) {
+div[data-testid="collapsedControl"]:hover path:nth-of-type(2),
+div[data-testid="stSidebarCollapsedControl"]:hover path:nth-of-type(2) {
     fill: {{ ui.hover_color }};
 }
-div[data-testid="collapsedControl"] button[data-testid="baseButton-headerNoPadding"]:hover {
+div[data-testid="collapsedControl"] button[data-testid="baseButton-headerNoPadding"]:hover,
+div[data-testid="stSidebarCollapsedControl"] button[data-testid="baseButton-headerNoPadding"]:hover {
     background-color: {{ ui.hover_bg_color }};
 }
 div[data-testid="stSidebarContent"] button[data-testid="baseButton-header"]:hover {

--- a/streamlit_navigation_bar/templates/options.css
+++ b/streamlit_navigation_bar/templates/options.css
@@ -7,7 +7,7 @@ span[data-testid="stMainMenu"] {
 {% endblock %}
 
 {% block hide_sidebar %}
-div[data-testid="collapsedControl"] {
+div[data-testid="collapsedControl"], div[data-testid="stSidebarCollapsedControl"] {
     visibility: hidden;
 }
 {% endblock %}


### PR DESCRIPTION
Use both the old and new classnames in the selectors.

Closes #26