### PR TITLE
Fix for invisible navigation bar

### DIFF
--- a/streamlit_navigation_bar/templates/base.css
+++ b/streamlit_navigation_bar/templates/base.css
@@ -1,10 +1,10 @@
 {# style the navbar #}
 iframe[title="streamlit_navigation_bar.st_navbar"] {
     height: {{ ui.height }};
-    left: 0;
-    margin-top: calc(-6rem + -{{ ui.height }});
     position: fixed;
     z-index: 9999;
+    top: 0px;
+    left: 0px;
     {% if margin %}
     width: calc(100% - 5.125rem);
     margin-left: 2.5625rem;


### PR DESCRIPTION
No idea why, but these changes fix the problem

I noticed that the top: 0 value was outside the viewport. Playing with the top value, I could replicate the correct location. However, removing the margin line solved the issue.

Closes #27 and #28.